### PR TITLE
fix output bundle path

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = {
   entry: './src/main.tsx',
   output: {
     path: path.resolve(__dirname, './dist'),
+    publicPath: '/',
     filename: 'build.js',
   },
   module: {


### PR DESCRIPTION
webpack の output の設定により、 bundle.js の参照パスがずれてしまっていた。
router を使った遷移時に path がネストされていると、ネストされた先の bundle.js を参照しようとして 404 となってしまう。
`publicPath: '/'` として修正