### PR TITLE
update node version to 18

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Install Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version-file: 'package.json'
 
     - name: Install pnpm
       uses: pnpm/action-setup@v2.2.4

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "type": "git",
     "url": "git+https://github.com/hey3/starter-for-react.git"
   },
+  "engines": {
+    "node": "18.x"
+  },
   "packageManager": "pnpm@7.17.0",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
actions/setup-node now supports for `engines.node`.